### PR TITLE
Update tree-sitter queries (highlights.scm, locals.scm) to match upstream

### DIFF
--- a/languages/move/highlights.scm
+++ b/languages/move/highlights.scm
@@ -35,8 +35,8 @@
 (module_identity module: (module_identifier)  @namespace.module.name)
 
 ;; Function calls
-(call_expression access: (module_access module: (module_identifier)  @namespace.module.name))
-(call_expression access: (module_access member: (identifier)  @function.call))
+(call_expression (name_expression access: (module_access module: (module_identifier)  @namespace.module.name)))
+(call_expression (name_expression access: (module_access member: (identifier)  @function.call)))
 
 
 (label (identifier)  @label)
@@ -76,18 +76,22 @@
 (variant variant_name: (variant_identifier)  @constructor.name)
 
 ;; Packs
-(pack_expression access: (module_access)  @constructor.name)
+(pack_expression (name_expression access: (module_access)  @constructor.name))
 
 ;; Unpacks
 ;; TODO: go into variants
-(bind_unpack (module_access)  @type.name)
+(bind_unpack (name_expression)  @type.name)
 (module_access "$" (identifier)  @macro.variable)
 "$"  @macro.variable
 
 (module_access module: (module_identifier)  member: (identifier) @constructor.name)
 
+(abort_expression) @keyword
+(mut_ref) @keyword
+
 ;; Lambdas
-(lambda_bindings (bind_var (variable_identifier)  @variable.parameter))
+; (lambda_binding bind: (bind_var (variable_identifier)  @variable.parameter))
+; (lambda_bindings (bind_var (variable_identifier)  @variable.parameter))
 
 
 ;; Operators
@@ -124,8 +128,7 @@
  "struct"
  "use"
  "public"
- "public(package)"
- "public(friend)"
+ "package"
  "spec"
  "module"
  "abort"
@@ -134,8 +137,6 @@
  "has"
  "as"
  "&"
- "&mut"
- "abort"
  "friend"
  "entry"
  "mut"

--- a/languages/move/locals.scm
+++ b/languages/move/locals.scm
@@ -1,17 +1,53 @@
-; Define the scope of a function based on function definition
-((function_definition
-  name: (identifier) @local.definition))
+; Function Scope
+; (function_definition
+;   body: (block) @scope
+;   parameters: (function_parameters (function_parameter name: (variable_identifier) @definition.var)))
 
-; Parameters in a function are defined as local variables
-(function_parameters
-  (function_parameter
-    (identifier) @local.definition))
+(function_definition body: (block) @scope)
 
-; When a variable is assigned a value, it's a definition
-; Assuming assignments are handled within expressions or specific assignment structures in Move
-(let_statement
-  name: (identifier) @local.definition)
+(function_parameter name: (variable_identifier) @definition.var)
+(function_parameter name: (variable_identifier) @local.definition)
 
-; Reference to identifiers within the scope of expressions
-; This general case assumes usage of variables within expressions or conditions
-((identifier) @local.reference)
+(identifier) @local.reference
+
+
+; Module and Struct Scope
+(module_definition
+  (module_body) @scope)
+
+; (struct_definition
+;   (struct_def_fields) @scope)
+
+; Spec Block Scope
+(spec_block
+  body: (spec_body) @scope)
+
+; Local Variable Declarations in Function Blocks
+; (let_statement
+;   binds: (bind_list
+;            (bind_var (variable_identifier) @definition.var)
+;            (bind_unpack
+;              (bind_field (field_identifier) @definition.var))))
+
+; Local Variable Declarations in Spec Blocks
+; (spec_block
+;   (spec_variable name: (identifier) @definition.var))
+
+; Parameters in Spec Functions
+; (spec_function
+;   parameters: (function_parameters (function_parameter name: (identifier) @definition.var)))
+;
+; ; Type Parameters
+; (type_parameters
+;   (type_parameter name: (identifier) @definition.type)))
+;
+; ; Struct Fields
+; (struct_definition
+;   (struct_def_fields
+;     (field_annotation
+;       field: (identifier) @definition.field)))
+;
+; ; Function and Module Identifiers
+; (function_definition name: (identifier) @definition.function)
+; (module_definition name: (identifier) @definition.module)
+;


### PR DESCRIPTION
See: https://github.com/zed-industries/extensions/pull/1799

Test failure:
https://github.com/zed-industries/extensions/actions/runs/12362668682/job/34502458829?pr=1799

> Error: Query error at 127:3. Invalid node type public

https://github.com/Tzal3x/move-zed-extension/blob/1ac098180c45ea583a6cdc5096cb8557e55cc95b/languages/move/highlights.scm#L126-L128

On line 127 `public(package)` is longer a valid query (upstream tree-sitter has changed)

So I took highlights.scm and locals.scm from [upstream commit](https://github.com/tzakian/tree-sitter-move/tree/f5b37f63569f69dfbe7a9950527786d2f6b1d35c/queries) (main tip) which matches the commit we're using to build the tree-sitter:
https://github.com/Tzal3x/move-zed-extension/blob/1ac098180c45ea583a6cdc5096cb8557e55cc95b/extension.toml#L18